### PR TITLE
Added check-tale script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update -y && apt-get install bash curl python3 python3-pip xinetd -y && \
-    pip3 install docker
+    pip3 install argparse docker
 
 COPY check_mk/etc /etc/
 COPY check_mk/usr /usr/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,5 +6,6 @@ mkdir -p /usr/lib/check_mk_agent/local
 cp /scripts/check-services /usr/lib/check_mk_agent/local
 cp /scripts/check-nodes /usr/lib/check_mk_agent/local
 cp /scripts/check-celery /usr/lib/check_mk_agent/local
+cp /scripts/check-tale /usr/lib/check_mk_agent/local/600/
 
 /usr/sbin/xinetd -f /etc/xinetd.conf -dontfork -stayalive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-mkdir -p /usr/lib/check_mk_agent/local/3600
+mkdir -p /usr/lib/check_mk_agent/local/600
 cp /scripts/check-services /usr/lib/check_mk_agent/local
 cp /scripts/check-nodes /usr/lib/check_mk_agent/local
 cp /scripts/check-celery /usr/lib/check_mk_agent/local
-cp /scripts/check-tale /usr/lib/check_mk_agent/local/3600/
+cp /scripts/check-tale /usr/lib/check_mk_agent/local/600
 
 /usr/sbin/xinetd -f /etc/xinetd.conf -dontfork -stayalive

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-mkdir -p /usr/lib/check_mk_agent/local
+mkdir -p /usr/lib/check_mk_agent/local/3600
 cp /scripts/check-services /usr/lib/check_mk_agent/local
 cp /scripts/check-nodes /usr/lib/check_mk_agent/local
 cp /scripts/check-celery /usr/lib/check_mk_agent/local

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,6 @@ mkdir -p /usr/lib/check_mk_agent/local
 cp /scripts/check-services /usr/lib/check_mk_agent/local
 cp /scripts/check-nodes /usr/lib/check_mk_agent/local
 cp /scripts/check-celery /usr/lib/check_mk_agent/local
-cp /scripts/check-tale /usr/lib/check_mk_agent/local/600/
+cp /scripts/check-tale /usr/lib/check_mk_agent/local/3600/
 
 /usr/sbin/xinetd -f /etc/xinetd.conf -dontfork -stayalive

--- a/scripts/check-tale
+++ b/scripts/check-tale
@@ -1,18 +1,31 @@
 import argparse
+import docker
 import requests
+import os
+import sys
 
 
 # Check_MK script to create and delete an instance of the specified tale
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("-s", "--server", required=True, help="Server URL")
-    parser.add_argument("-k", "--key", required=True, help="API key")
-    parser.add_argument("-t", "--tale", required=True, help="Tale ID")
-
+    # Allow arguments via command line and environment
+    parser.add_argument("-s", "--server", required=False, help="Server URL", default=os.environ.get('GIRDER_URL', None))
+    parser.add_argument("-k", "--key", required=False, help="API key", default=os.environ.get('GIRDER_API_KEY', None))
+    parser.add_argument("-t", "--tale", required=False, help="Tale ID", default=os.environ.get('TALE_ID', None))
+    parser.add_argument("-d", "--dev", required=False, help="Development mode", default=False)
     args = parser.parse_args()
 
     apiUrl = "%s/api/v1" % args.server
+
+    # Unless in dev mode, only run this check on the Swarm master
+    if args.dev:
+       print("server=%s key=%s tale=%s" % (args.server, args.key, args.tale))
+    else:
+       client = docker.from_env()
+       attrs = client.swarm.attrs
+       if not attrs.get("ID"):
+           sys.exit(0)
 
     token = get_token(apiUrl, args.key)
     if token is not None:

--- a/scripts/check-tale
+++ b/scripts/check-tale
@@ -4,10 +4,13 @@ import docker
 import requests
 import os
 import sys
+import logging
 
 
 # Check_MK script to create and delete an instance of the specified tale
 def main():
+
+    logging.basicConfig(filename='check-tale.log',level=logging.DEBUG)
     parser = argparse.ArgumentParser()
 
     # Allow arguments via command line and environment
@@ -43,9 +46,11 @@ def get_token(apiUrl, key):
             return body['authToken']['token']
         else:
             print("2 Tale status=%s CRITICAL - error getting token" % r.status_code)
+            logging.error("Error getting token " % r.content)
 
     except Exception as e:
         print("2 Tale status=failed CRITICAL - unexpected exception getting token")
+        logging.exception("Exception getting token")
 
     return None
 
@@ -67,11 +72,14 @@ def create_instance(apiUrl, token, tale):
                 print("0 Tale status=%s OK - tale successfully created/deleted" % r.status_code )
             else:
                 print("2 Tale status=%s CRITICAL - error deleting tale" % r.status_code)
+                logging.error("Error deleting tale " % r.content)
         else:
             print("2 Tale status=%s CRITICAL - error creating tale" % r.status_code)
+            logging.error("Error creating tale " % r.content)
 
     except Exception as e:
         print("2 Tale status=failed CRITICAL - unexpected exception creating tale")
+        logging.exception("Exception creating tale")
 
 if __name__ == "__main__":
     main()

--- a/scripts/check-tale
+++ b/scripts/check-tale
@@ -1,0 +1,64 @@
+import argparse
+import requests
+
+
+# Check_MK script to create and delete an instance of the specified tale
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("-s", "--server", required=True, help="Server URL")
+    parser.add_argument("-k", "--key", required=True, help="API key")
+    parser.add_argument("-t", "--tale", required=True, help="Tale ID")
+
+    args = parser.parse_args()
+
+    apiUrl = "%s/api/v1" % args.server
+
+    token = get_token(apiUrl, args.key)
+    if token is not None:
+        create_instance(apiUrl, token, args.tale)
+
+
+# Get a token for the API key
+def get_token(apiUrl, key):
+    try:
+        tokenUrl = "%s/api_key/token?key=%s" % (apiUrl, key)
+        r = requests.post(tokenUrl, headers={'Accept': 'application/json', 'Content-Type': 'application/json'})
+        if r.status_code == requests.codes.ok:
+            body = r.json()
+            return body['authToken']['token']
+        else:
+            print("2 Tale status=%s CRITICAL - error getting token" % r.status_code)
+
+    except Exception as e:
+        print("2 Tale status=failed CRITICAL - unexpected exception getting token")
+
+    return None
+
+
+# Create and delete an instance of the specified tale
+def create_instance(apiUrl, token, tale):
+
+    try:
+        postInstanceUrl = "%s/instance?taleId=%s" % (apiUrl, tale)
+        r = requests.post(postInstanceUrl, headers={'Girder-Token': token, 'Content-Type': 'application/json',
+                                                    'Accept': 'application/json'})
+        if r.status_code == requests.codes.ok:
+            body = r.json()
+            instanceId = body['_id']
+
+            deleteInstanceUrl = "%s/instance/%s" % (apiUrl, instanceId)
+            r = requests.delete(deleteInstanceUrl, headers={'Girder-Token': token, 'Accept': 'application/json'})
+            if r.status_code == requests.codes.ok:
+                print("0 Tale status=%s OK - tale successfully created/deleted")
+            else:
+                print("2 Tale status=%s CRITICAL - error deleting tale" % r.status_code)
+        else:
+            print("2 Tale status=%s CRITICAL - error creating tale" % r.status_code)
+
+    except Exception as e:
+        print("2 Tale status=failed CRITICAL - unexpected exception creating tale")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/check-tale
+++ b/scripts/check-tale
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 import argparse
 import docker
 import requests
@@ -63,7 +64,7 @@ def create_instance(apiUrl, token, tale):
             deleteInstanceUrl = "%s/instance/%s" % (apiUrl, instanceId)
             r = requests.delete(deleteInstanceUrl, headers={'Girder-Token': token, 'Accept': 'application/json'})
             if r.status_code == requests.codes.ok:
-                print("0 Tale status=%s OK - tale successfully created/deleted")
+                print("0 Tale status=%s OK - tale successfully created/deleted" % r.status_code )
             else:
                 print("2 Tale status=%s CRITICAL - error deleting tale" % r.status_code)
         else:


### PR DESCRIPTION
Implements check_mk part of https://github.com/whole-tale/terraform_deployment/issues/7

Added `check-tale` local check to launch and delete a tale.  

Run via CLI locally, the `-d` flag bypasses the Swarm master check:
`
python scripts/check-tale -s https://girder.prod.wholetale.org -k <girder api key> -t <tale ID> -d True
`
The script will ultimately be run via the `check_mk` container, so environment variables are required.  

Note that the `check_mk/local/3600` path in the entrypoint is part of the "cached local check" model described in https://mathias-kettner.de/checkmk_localchecks.html. In short, the tale check will only run every hour.

I've also configured on staging and am running an updated image `wholetale/check_mk:ligo-test`. Status can be seen via OMD.


